### PR TITLE
fix(secrets): triage secrets

### DIFF
--- a/sfdc_metadata/cred_scan_triage/triage.yaml
+++ b/sfdc_metadata/cred_scan_triage/triage.yaml
@@ -1,0 +1,9 @@
+clean: true
+mock_secret:
+- id: utam-java-recipes://README.md_50203e027c8334339cea4070a6b5940230a08044
+  justification: example secret in documentation
+- id: utam-java-recipes://CONTRIBUTING.md_50203e027c8334339cea4070a6b5940230a08044
+  justification: example secret in documentation
+false_positive: []
+non_production_secret: []
+production_secret: []


### PR DESCRIPTION
Automated tooling has flagged the use of "PASSWORD=strongPassword" and
"PASSWORD=password" in the readme as a possible secret in this repo.

This metadata file triages it as a mock secret.